### PR TITLE
Only import facebook lib when sending to facebook

### DIFF
--- a/generate_pizza.py
+++ b/generate_pizza.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import numpy as np
 import random
-import facebook
 from pandas import read_csv
 from argparse import ArgumentParser
 import smtplib
@@ -63,6 +62,7 @@ def getpw():
     return pw
 
 def post(pizza):
+    import facebook
     #do a facebook post
     graph = facebook.GraphAPI(access_token=getToken(), version = "3.1")
     graph.put_object(parent_object='me', connection_name='feed',


### PR DESCRIPTION
Moved the import of the facebook library into the send function, the only place it is needed, so that one can get recipes offline without installing yucky facebook lib stuff.

(The import is only actually done the first time the function is started.)